### PR TITLE
Add local frontend env dev configuration

### DIFF
--- a/flapjack_frontend/.env.dev
+++ b/flapjack_frontend/.env.dev
@@ -1,0 +1,2 @@
+REACT_APP_HTTP_API=http://localhost:8000/api/
+REACT_APP_WS_API=ws://localhost:8000/ws/


### PR DESCRIPTION
## Summary
- add local API and WebSocket endpoints to the frontend development environment file

## Testing
- npm ci (fails: registry and node headers returned HTTP 403 in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692758308b7883309d36335d3dba7f15)